### PR TITLE
Fix URL encoding/decoding in the "store a document" form

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Fix a bug where tags with URL-encoded characters would be displayed incorrectly in the "store a document" form.

--- a/src/api.py
+++ b/src/api.py
@@ -76,7 +76,7 @@ def create_api(store, display_title="Alex’s documents"):
 
         search_response = search_helpers.search_store(store, options=search_options)
 
-        req_url = hyperlink.URL.from_text(req.full_url)
+        req_url = hyperlink.DecodedURL.from_text(req.full_url)
 
         params = {k: v for k, v in req.params.items()}
         try:

--- a/src/tests/test_viewer.py
+++ b/src/tests/test_viewer.py
@@ -133,3 +133,24 @@ def test_version_is_shown_in_footer(sess):
     footer = soup.find("footer")
 
     assert re.search(r'docstore v\d+\.\d+\.\d+', str(footer)) is not None
+
+
+class TestStoreDocumentForm:
+    def test_url_decodes_tags_before_displaying(self, sess, pdf_file):
+        """
+        Check that URL-encoded entities get unwrapped when we display the tag form.
+
+        e.g. "colour:blue" isn't displayed as "colour%3Ablue"
+
+        """
+        sess.post(
+            "/upload",
+            files={"file": ("mydocument.pdf", pdf_file)},
+            data={"tags": ["colour:blue"]}
+        )
+
+        resp = sess.get("/", params={"tag": "colour:blue"})
+
+        soup = bs4.BeautifulSoup(resp.text, "html.parser")
+        tag_field = soup.find("input", attrs={"name": "tags"})
+        assert tag_field.attrs["value"] == "colour:blue"


### PR DESCRIPTION
Closes #31