### PR TITLE
Shorten the date strings in the UI

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Tweak the display of dates in the table UI to avoid line wrapping.

--- a/src/date_helpers.py
+++ b/src/date_helpers.py
@@ -33,7 +33,7 @@ def relative_date_str(x, y):
         else:
             return "%d days ago" % days
     else:
-        return min([x, y]).strftime("%-d %B %Y")
+        return min([x, y]).strftime("%-d %b %Y")
 
 
 def since_now_date_str(x):

--- a/src/tests/test_date_helpers.py
+++ b/src/tests/test_date_helpers.py
@@ -19,9 +19,9 @@ NOW = dt.datetime.now()
     (NOW, NOW - dt.timedelta(seconds=60 * 60 * 3 + 15 * 60), "3 hours ago"),
     (NOW, NOW - dt.timedelta(seconds=60 * 60 * 24 + 1), "1 day ago"),
     (NOW, NOW - dt.timedelta(seconds=60 * 60 * 24 * 3 + 1), "3 days ago"),
-    (NOW, NOW + dt.timedelta(seconds=60 * 60 * 24 * 10 + 1), NOW.strftime("%-d %B %Y")),
-    (dt.datetime(2000, 2, 3), NOW, "3 February 2000"),
-    (dt.datetime(2000, 1, 1), dt.datetime(2000, 1, 30), "1 January 2000"),
+    (NOW, NOW + dt.timedelta(seconds=60 * 60 * 24 * 10 + 1), NOW.strftime("%-d %b %Y")),
+    (dt.datetime(2000, 2, 3), NOW, "3 Feb 2000"),
+    (dt.datetime(2000, 1, 1), dt.datetime(2000, 1, 30), "1 Jan 2000"),
 ])
 def test_relative_date_str(x, y, expected_relative_str):
     assert relative_date_str(x, y) == expected_relative_str

--- a/src/tests/test_date_helpers.py
+++ b/src/tests/test_date_helpers.py
@@ -20,6 +20,8 @@ NOW = dt.datetime.now()
     (NOW, NOW - dt.timedelta(seconds=60 * 60 * 24 + 1), "1 day ago"),
     (NOW, NOW - dt.timedelta(seconds=60 * 60 * 24 * 3 + 1), "3 days ago"),
     (NOW, NOW + dt.timedelta(seconds=60 * 60 * 24 * 10 + 1), NOW.strftime("%-d %B %Y")),
+    (dt.datetime(2000, 2, 3), NOW, "3 February 2000"),
+    (dt.datetime(2000, 1, 1), dt.datetime(2000, 1, 30), "1 January 2000"),
 ])
 def test_relative_date_str(x, y, expected_relative_str):
     assert relative_date_str(x, y) == expected_relative_str


### PR DESCRIPTION
Cos this is a bit rubbish:

![Screenshot 2019-04-23 at 17 00 58](https://user-images.githubusercontent.com/301220/56596946-6357e200-65e9-11e9-9ef8-7a624f604679.png)
