### PR TITLE
Fix a cosmetic issue with tag display

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Fix a tiny cosmetic issue in the display of tags on an individual document.

--- a/src/templates/document_list.html
+++ b/src/templates/document_list.html
@@ -72,7 +72,7 @@
                   <a href="{{ req_url.add('tag', tag) | query_str_only }}">
                 {% endif %}
                 #{{ tag }}
-                {% if tag not in search_options.tag_query %}</a>{% endif %}
+                {%- if tag not in search_options.tag_query %}</a>{% endif %}
                 {% endfor %}
                 </h5>
               </div>


### PR DESCRIPTION
The template was adding an extra space after the tag name, so the link text would be "mytag "; this removes the extra space.