### PR TITLE
Fix an off-by-one error in the version displayed in the footer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,14 +11,6 @@ $(ROOT)/.docker/tests: build test_requirements.txt
 	mkdir -p $(ROOT)/.docker
 	touch $(ROOT)/.docker/tests
 
-$(ROOT)/.docker/pip_tools: $(ROOT)/.docker/base
-	docker build --tag docstore_pip_tools --file docker/pip_tools.Dockerfile .
-	mkdir -p $(ROOT)/.docker
-	touch $(ROOT)/.docker/pip_tools
-
-deps = $(ROOT)/.docker/base docker/app.Dockerfile requirements.txt $(wildcard $(ROOT)/src/*)
-
-
 lint:
 	docker run --rm --volume $(ROOT):/src wellcome/flake8:65 --ignore=E501,W504
 
@@ -36,10 +28,12 @@ test-fast:
 	docker run --tty --volume $(ROOT):$(ROOT) --workdir $(ROOT) \
 		--entrypoint "coverage" docstore_tests report
 
-requirements.txt: $(ROOT)/.docker/pip_tools requirements.in
+requirements.txt:
+	docker build --tag docstore_pip_tools --file docker/pip_tools.Dockerfile .
 	docker run -v $(ROOT):/src --workdir /src docstore_pip_tools requirements.in
 
-test_requirements.txt: $(ROOT)/.docker/pip_tools requirements.txt test_requirements.in
+test_requirements.txt:
+	docker build --tag docstore_pip_tools --file docker/pip_tools.Dockerfile .
 	docker run -v $(ROOT):/src --workdir /src docstore_pip_tools test_requirements.in
 
 check_release_file:

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ $(ROOT)/.docker/base: docker/base.Dockerfile
 	mkdir -p $(ROOT)/.docker
 	touch $(ROOT)/.docker/base
 
-$(ROOT)/.docker/tests: $(ROOT)/.docker/app test_requirements.txt
+$(ROOT)/.docker/tests: build test_requirements.txt
 	docker build --tag docstore_tests --file docker/tests.Dockerfile .
 	mkdir -p $(ROOT)/.docker
 	touch $(ROOT)/.docker/tests
@@ -18,16 +18,12 @@ $(ROOT)/.docker/pip_tools: $(ROOT)/.docker/base
 
 deps = $(ROOT)/.docker/base docker/app.Dockerfile requirements.txt $(wildcard $(ROOT)/src/*)
 
-$(ROOT)/.docker/app: $(deps)
-	docker build --tag docstore --file docker/app.Dockerfile .
-	mkdir -p $(ROOT)/.docker
-	touch $(ROOT)/.docker/app
-
 
 lint:
 	docker run --rm --volume $(ROOT):/src wellcome/flake8:65 --ignore=E501,W504
 
-build: $(ROOT)/.docker/app
+build: $(ROOT)/.docker/base
+	docker build --tag docstore --file docker/app.Dockerfile .
 
 test: $(ROOT)/.docker/tests test-fast
 

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ $(ROOT)/.docker/base: docker/base.Dockerfile
 	mkdir -p $(ROOT)/.docker
 	touch $(ROOT)/.docker/base
 
-$(ROOT)/.docker/tests: $(ROOT)/.docker/app
+$(ROOT)/.docker/tests: $(ROOT)/.docker/app test_requirements.txt
 	docker build --tag docstore_tests --file docker/tests.Dockerfile .
 	mkdir -p $(ROOT)/.docker
 	touch $(ROOT)/.docker/tests
@@ -16,7 +16,9 @@ $(ROOT)/.docker/pip_tools: $(ROOT)/.docker/base
 	mkdir -p $(ROOT)/.docker
 	touch $(ROOT)/.docker/pip_tools
 
-$(ROOT)/.docker/app: $(ROOT)/.docker/base $(wildcard $(ROOT)/src/*)
+deps = $(ROOT)/.docker/base docker/app.Dockerfile requirements.txt $(wildcard $(ROOT)/src/*)
+
+$(ROOT)/.docker/app: $(deps)
 	docker build --tag docstore --file docker/app.Dockerfile .
 	mkdir -p $(ROOT)/.docker
 	touch $(ROOT)/.docker/app

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ $(ROOT)/.docker/pip_tools: $(ROOT)/.docker/base
 	mkdir -p $(ROOT)/.docker
 	touch $(ROOT)/.docker/pip_tools
 
-$(ROOT)/.docker/app: $(ROOT)/.docker/base
+$(ROOT)/.docker/app: $(ROOT)/.docker/base $(wildcard $(ROOT)/src/*)
 	docker build --tag docstore --file docker/app.Dockerfile .
 	mkdir -p $(ROOT)/.docker
 	touch $(ROOT)/.docker/app

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Fix a bug where the version in the footer would always show the previous version, not the current version.

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,7 +33,7 @@ pillow==6.1.0
 preview-generator==0.10
 promise==2.2.1            # via graphql-core, graphql-relay, graphql-server-core
 pyexifinfo==0.4.0         # via preview-generator
-pyparsing==2.4.1          # via packaging
+pyparsing==2.4.1.1        # via packaging
 pypdf2==1.26.0            # via preview-generator
 pyscss==1.3.5
 python-magic==0.4.15

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -46,7 +46,7 @@ py==1.8.0                 # via pytest
 pycodestyle==2.5.0        # via flake8
 pyexifinfo==0.4.0
 pyflakes==2.1.1           # via flake8
-pyparsing==2.4.1
+pyparsing==2.4.1.1
 pypdf2==1.26.0
 pyscss==1.3.5
 pytest-cov==2.7.1


### PR DESCRIPTION
Fixes #77.

The problem: Azure Pipelines builds a copy of the app as a precursor to running the tests (`make test` ~> `make build`). The release tooling calls `make build` a second time to create the release image, but it wasn’t looking for changes in `src`, so it assumed the old image was correct.