### PR TITLE
Move the CSS compilation out of create_api()

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+More internal refactoring to improve the speed of the test suite.

--- a/src/api.py
+++ b/src/api.py
@@ -62,17 +62,7 @@ def prepare_form_data(user_data):
     return prepared_data
 
 
-def create_api(
-    tagged_store,
-    root,
-    display_title="Alex’s documents",
-    default_view="table",
-    tag_view="list",
-    accent_color="#007bff"
-):
-    file_manager = FileManager(root / "files")
-    thumbnail_manager = ThumbnailManager(root / "thumbnails")
-
+def compile_css(accent_color):
     src_root = pathlib.Path(__file__).parent
     static_dir = src_root / "static"
 
@@ -87,6 +77,21 @@ def create_api(
 
     css_path = static_dir / "style.css"
     css_path.write_text(css)
+
+
+def create_api(
+    tagged_store,
+    root,
+    display_title="Alex’s documents",
+    default_view="table",
+    tag_view="list",
+    accent_color="#007bff"
+):
+    file_manager = FileManager(root / "files")
+    thumbnail_manager = ThumbnailManager(root / "thumbnails")
+
+    src_root = pathlib.Path(__file__).parent
+    static_dir = src_root / "static"
 
     api = responder.API(
         static_dir=static_dir,
@@ -290,6 +295,8 @@ def run_api(root, title, default_view, tag_view, accent_color):
     tagged_store = JsonTaggedObjectStore(root / "documents.json")
 
     migrations.apply_migrations(root=root, object_store=tagged_store)
+
+    compile_css(accent_color=accent_color)
 
     api = create_api(
         tagged_store,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -213,7 +213,10 @@ def test_lookup_missing_document_is_404(api):
     assert resp.status_code == 404
 
 
-def test_resolves_css(api):
+def test_resolves_css(tagged_store, store_root):
+    service.compile_css(accent_color="#ff0000")
+
+    api = service.create_api(tagged_store, root=store_root)
     resp = api.requests.get("/")
     soup = bs4.BeautifulSoup(resp.text, "html.parser")
 


### PR DESCRIPTION
I did some profiling, and noticed we spent a lot of time in SCSS functions in the tests, even though they're barely used!

Knocks off another ~9s on my MacBook.