### PR TITLE
Use streaming requests in tests for a big speedup

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,5 +1,20 @@
 # -*- encoding: utf-8
 
+# Implementation note: I've found that using this pattern is very slow:
+#
+#   resp = requests.get("/")
+#   resp.text
+#
+# For some reason, encoding the bytes back into a UTF-8 string is really expensive.
+# Possibly something to do with coverage inspecting the contents of ``text``?
+#
+# This is significantly faster, and in most tests can be used with
+# minimal extra complexity:
+#
+#   resp = requests.get("/", stream=True)
+#   resp.raw.read()
+#
+
 import io
 import time
 
@@ -103,19 +118,18 @@ def test_get_view_endpoint(api, png_file):
     }
     api.requests.post("/upload", files={"file": png_file}, data=data)
 
-    resp = api.requests.get("/")
+    resp = api.requests.get("/", stream=True)
     assert resp.status_code == 200
-    assert data["title"] in resp.text
+    assert b"Hello world" in resp.raw.read()
 
 
 def test_can_view_file_and_thumbnail(api, png_file, png_path):
     api.requests.post("/upload", files={"file": png_file})
 
-    resp = api.requests.get("/")
+    resp = api.requests.get("/", stream=True)
     assert resp.status_code == 200
-    assert resp.text != "null"
 
-    soup = bs4.BeautifulSoup(resp.text, "html.parser")
+    soup = bs4.BeautifulSoup(resp.raw.read(), "html.parser")
 
     all_links = soup.find_all("a", attrs={"target": "_blank"})
     png_links = list(set(
@@ -155,11 +169,10 @@ def test_can_view_existing_file_and_thumbnail(
 
     new_api = service.create_api(tagged_store, root=store_root)
 
-    resp = new_api.requests.get("/")
+    resp = new_api.requests.get("/", stream=True)
     assert resp.status_code == 200
-    assert resp.text != "null"
 
-    soup = bs4.BeautifulSoup(resp.text, "html.parser")
+    soup = bs4.BeautifulSoup(resp.raw.read(), "html.parser")
 
     all_links = soup.find_all("a", attrs={"target": "_blank"})
     png_links = list(set(
@@ -206,8 +219,8 @@ def test_resolves_css(tagged_store, store_root):
     service.compile_css(accent_color="#ff0000")
 
     api = service.create_api(tagged_store, root=store_root)
-    resp = api.requests.get("/")
-    soup = bs4.BeautifulSoup(resp.text, "html.parser")
+    resp = api.requests.get("/", stream=True)
+    soup = bs4.BeautifulSoup(resp.raw.read(), "html.parser")
 
     css_links = [
         link.attrs["href"]
@@ -331,14 +344,14 @@ def test_can_navigate_to_tag(api, png_file, tag):
         data={"tags": [tag], "title": "hello world"}
     )
 
-    resp = api.requests.get("/")
-    soup = bs4.BeautifulSoup(resp.text, "html.parser")
+    resp = api.requests.get("/", stream=True)
+    soup = bs4.BeautifulSoup(resp.raw.read(), "html.parser")
 
     tag_div = soup.find("div", attrs={"id": "collapseTagList"})
     link_to_tag = tag_div.find("ul").find("li").find("a").attrs["href"]
 
-    resp = api.requests.get("/" + link_to_tag)
-    assert "hello world" in resp.text
+    resp = api.requests.get("/" + link_to_tag, stream=True)
+    assert b"hello world" in resp.raw.read()
 
 
 def test_sets_caching_headers_on_file(api, png_file):
@@ -369,9 +382,9 @@ def test_can_filter_by_tag(api, tagged_store, file_manager):
         file_manager,
         doc_id="1",
         doc={
-            "file": b"hello world",
+            "file": b"1234",
             "title": "hello world",
-            "tags": ["bar", "baz"]
+            "tags": ["x", "y"]
         }
     )
     index_new_document(
@@ -379,39 +392,49 @@ def test_can_filter_by_tag(api, tagged_store, file_manager):
         file_manager,
         doc_id="2",
         doc={
-            "file": b"hi world",
+            "file": b"5678",
             "title": "hi world",
-            "tags": ["bar", "bat"]
+            "tags": ["x", "z"]
         }
     )
 
-    resp_bar = api.requests.get("/", params={"tag": "bar"})
-    assert "hello world" in resp_bar.text
-    assert "hi world" in resp_bar.text
+    resp_tag_x = api.requests.get(
+        "/", params=[("tag", "x")], stream=True
+    )
+    html_x_bytes = resp_tag_x.raw.read()
+    assert b"hello world" in html_x_bytes
+    assert b"hi world" in html_x_bytes
 
-    resp_bat = api.requests.get("/", params={"tag": ["bar", "bat"]})
-    assert "hello world" not in resp_bat.text
-    assert "hi world" in resp_bat.text
+    resp_tag_x_y = api.requests.get(
+        "/", params=[("tag", "x"), ("tag", "y")], stream=True
+    )
+    html_x_y_bytes = resp_tag_x_y.raw.read()
+    assert b"hello world" in html_x_y_bytes
+    assert b"hi world" not in html_x_y_bytes
 
 
-def test_uses_display_title(tagged_store, store_root):
+def test_uses_display_title(store_root, tagged_store):
     title = "My docstore title"
 
     api = service.create_api(tagged_store, store_root, display_title=title)
-    resp = api.requests.get("/")
-    assert title in resp.text
+
+    resp = api.requests.get("/", stream=True)
+
+    assert b"My docstore title" in resp.raw.read()
 
 
 class TestListView:
     @staticmethod
-    def _assert_is_table(html):
-        assert '<main class="documents documents__view_grid">' not in html
-        assert '<main class="documents documents__view_table">' in html
+    def _assert_is_table(resp):
+        html_bytes = resp.raw.read()
+        assert b'<main class="documents documents__view_grid">' not in html_bytes
+        assert b'<main class="documents documents__view_table">' in html_bytes
 
     @staticmethod
-    def _assert_is_grid(html):
-        assert '<main class="documents documents__view_grid">' in html
-        assert '<main class="documents documents__view_table">' not in html
+    def _assert_is_grid(resp):
+        html_bytes = resp.raw.read()
+        assert b'<main class="documents documents__view_grid">' in html_bytes
+        assert b'<main class="documents documents__view_table">' not in html_bytes
 
     def test_can_set_default_table_view(self, store_root, tagged_store, file_manager):
         index_new_document(
@@ -421,8 +444,8 @@ class TestListView:
             doc={"file": b"hello world", "title": "xyz"}
         )
         api = service.create_api(tagged_store, store_root, default_view="table")
-        resp = api.requests.get("/")
-        self._assert_is_table(resp.text)
+        resp = api.requests.get("/", stream=True)
+        self._assert_is_table(resp)
 
     def test_can_set_default_grid_view(self, store_root, tagged_store, file_manager):
         index_new_document(
@@ -432,5 +455,5 @@ class TestListView:
             doc={"file": b"hello world", "title": "xyz"}
         )
         api = service.create_api(tagged_store, store_root, default_view="grid")
-        resp = api.requests.get("/")
-        self._assert_is_grid(resp.text)
+        resp = api.requests.get("/", stream=True)
+        self._assert_is_grid(resp)


### PR DESCRIPTION
It turns out that `resp.text` is a big source of test slowness, which is unexpected.