### PR TITLE
Fix a concurrency issue with thumbnails

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Fix a bug where new thumbnails wouldn't reload until you restarted the app.

--- a/src/api.py
+++ b/src/api.py
@@ -2,7 +2,6 @@
 # -*- encoding: utf-8
 
 import json
-import multiprocessing
 import os
 import pathlib
 import shutil
@@ -337,9 +336,6 @@ def run_api(config):  # pragma: no cover
 
     docstore = Docstore(tagged_store, config=config)
 
-    def number_of_workers():
-        return (multiprocessing.cpu_count() * 2) + 1
-
     # From https://docs.gunicorn.org/en/stable/custom.html
     class StandaloneApplication(gunicorn.app.base.BaseApplication):
 
@@ -359,7 +355,7 @@ def run_api(config):  # pragma: no cover
 
     options = {
         "bind": "0.0.0.0:%s" % os.environ.get("PORT", 8072),
-        "workers": number_of_workers(),
+        "workers": 1,
     }
 
     StandaloneApplication(docstore.app.wsgi_app, options).run()


### PR DESCRIPTION
Because gunicorn is running multiple workers, adding a new thumbnail only register in the current worker -- reduce the number of workers to 1, I'm the only person ever using the app.

If I was doing this on a bigger scale, whitenoise is the wrong tool for the job.