### PR TITLE
Tweak a bit of wording in the UI

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Tweak a bit of wording in the UI.

--- a/src/templates/_collapsibles.html
+++ b/src/templates/_collapsibles.html
@@ -39,7 +39,7 @@
           <input name="file" type="file" class="form-control-file" id="form__file" required>
         </div>
 
-        <button type="submit" class="btn btn-primary">Submit</button>
+        <button type="submit" class="btn btn-primary">Store document!</button>
       </form>
     </div>
   </div>

--- a/src/templates/document_list.html
+++ b/src/templates/document_list.html
@@ -52,7 +52,7 @@
 
             <div class="document__info">
               <div class="document__metadata document__metadata__date_created">
-                <p class="document__metadata__title">date created</p>
+                <p class="document__metadata__title">date stored</p>
                 <h5 class="document__metadata__info">{{ doc["date_created"] | since_now_date_str }}</h5>
               </div>
 


### PR DESCRIPTION
Creating screenshots to put in a blog post exposed some clunky wording. In particular, I use three verbs to describe the act of putting a document into docstore: “store”, “submit” and “create”. Use the first one consistently, at least in the UI.