### PR TITLE
Don't scale to y=1 in Cairo

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Fix a bug in v1.20.5 that broke thumbnailing of PDFs.

--- a/src/thumbnails.py
+++ b/src/thumbnails.py
@@ -57,7 +57,7 @@ def _get_pdf_preview(path):
     assert isinstance(path, pathlib.Path)
     _, out_path = tempfile.mkstemp()
     subprocess.check_call([
-        "pdftocairo", str(path), "-jpeg", "-singlefile", "-scale-to-x", "1200", "-scale-to-y", "1", out_path
+        "pdftocairo", str(path), "-jpeg", "-singlefile", "-scale-to-x", "1200", out_path
     ])
     jpg_path = pathlib.Path(out_path + ".jpg")
     assert jpg_path.exists()

--- a/tests/test_thumbnails.py
+++ b/tests/test_thumbnails.py
@@ -9,19 +9,23 @@ from thumbnails import create_thumbnail
 
 
 @pytest.mark.parametrize(
-    "filename, expected_ext",
+    "filename, expected_ext, expected_height",
     [
-        ("bridge.jpg", ".jpg"),
-        ("cluster.png", ".png"),
-        ("metamorphosis.epub", ".jpg"),
-        ("snakes.pdf", ".jpg"),
+        ("bridge.jpg", ".jpg", 300),
+        ("cluster.png", ".png", 260),
+        ("metamorphosis.epub", ".jpg", 533),
+        ("snakes.pdf", ".jpg", 585),
     ]
 )
-def test_create_thumbnail(filename, expected_ext):
+def test_create_thumbnail(filename, expected_ext, expected_height):
     path = pathlib.Path("tests/files") / filename
     result = create_thumbnail(path)
     assert result.suffix == expected_ext
     assert result.exists()
+
+    im = Image.open(result)
+    assert im.width == 400
+    assert im.height == expected_height
 
 
 @pytest.mark.parametrize("filename", ["helloworld.rb", "README.md"])


### PR DESCRIPTION
Turns out this broke the thumbnails of PDFs.